### PR TITLE
u-boot-menu: default: Update U_BOOT_FDT variable

### DIFF
--- a/default
+++ b/default
@@ -10,6 +10,6 @@ U_BOOT_MENU_LABEL="Vicharak Linux Kernel"
 U_BOOT_PARAMETERS=$(cat /etc/kernel/cmdline)
 #U_BOOT_ROOT=""
 U_BOOT_TIMEOUT="10"
-U_BOOT_FDT="rk3399-vaaman-linux.dtb"
+U_BOOT_FDT="rk-kernel.dtb"
 U_BOOT_FDT_DIR="/usr/lib/linux-image-$(uname -r)/rockchip"
 U_BOOT_FDT_OVERLAYS_DIR="/boot/overlays"


### PR DESCRIPTION
The `U_BOOT_FDT ` variable holds the name of VIcharak board's specific device tree file.
`rk-kernel.dtb` is a symlink to the board's specific DTB file in the boot partition, thus can be used for any of  the Vicharak boards.
 